### PR TITLE
Revert "Djot.Blocks: use ByteString directly in `toIdentifier` (#1)"

### DIFF
--- a/src/Djot/Blocks.hs
+++ b/src/Djot/Blocks.hs
@@ -26,6 +26,7 @@ import qualified Data.ByteString.Char8 as B8
 import Data.ByteString (ByteString)
 import Control.Monad (replicateM_, void, mzero, unless, when, guard, foldM)
 import Data.List.NonEmpty (NonEmpty(..))
+import Data.List (intercalate)
 import qualified Data.List.NonEmpty as NonEmpty
 import Data.Set (Set)
 import qualified Data.Set as Set
@@ -1126,11 +1127,12 @@ closeContainingSections lev = do
       closeContainingSections lev
     _ -> pure ()
 
+-- TODO avoid detour through String
 toIdentifier :: ByteString -> ByteString
 toIdentifier bs =
   if null parts
      then "sec"
-     else B8.intercalate (B8.singleton '-') parts
+     else strToUtf8 $ intercalate "-" parts
  where
    isSym = (`elem` ("][~!@#$%^&*(){}`,.<>\\|=+/" :: [Char]))
-   parts = B8.words $ B8.map (\c -> if isSym c then ' ' else c) bs
+   parts = words $ map (\c -> if isSym c then ' ' else c) $ utf8ToStr bs


### PR DESCRIPTION
This reverts commit a68208b25d955c63babf9602b34f47ba2a6364fb.