### PR TITLE
add Lift derivations to AST datatypes

### DIFF
--- a/djot.cabal
+++ b/djot.cabal
@@ -17,15 +17,24 @@ extra-doc-files:    CHANGELOG.md
 extra-source-files: test/*.test
                     benchmark/m.dj
 
+common deps
+  build-depends:
+    base >= 4.12 && < 5,
+    bytestring >= 0.11.3,
+    text,
+    doclayout
+
 Library
-    build-depends:    base >= 4.12 && < 5,
-                      bytestring >= 0.11.3,
-                      containers,
-                      mtl,
-                      text,
-                      doclayout,
-                      template-haskell,
-                      th-lift-instances
+    import:           deps
+    build-depends:    mtl,
+                      template-haskell
+    if impl(ghc > 9.2)
+      build-depends:
+        containers >= 0.6.6
+    else
+      build-depends:
+        containers,
+        th-lift-instances
     hs-source-dirs:   src
     default-language: Haskell2010
     exposed-modules:  Djot
@@ -40,49 +49,38 @@ Library
     ghc-options: -Wall -O2
 
 executable djoths
+    import:           deps
     main-is:          Main.hs
-    build-depends:    base >= 4.12 && < 5,
-                      djot,
-                      bytestring,
-                      containers,
-                      text,
-                      doclayout
+    build-depends:    djot
     hs-source-dirs:   app
     default-language: Haskell2010
     ghc-options: -Wall -O2 -rtsopts -threaded
 
 test-suite test-djot
+  import: deps
   type: exitcode-stdio-1.0
   main-is: Main.hs
   hs-source-dirs: test
   ghc-options: -Wall -threaded -rtsopts -with-rtsopts=-K40K -with-rtsopts=-kc40K
   if impl(ghc >= 8.10)
     ghc-options:      -Wunused-packages
-  build-depends:
-      base >= 4.12 && <5
-    , djot
-    , text
-    , bytestring
-    , directory
-    , filepath
-    , doclayout
-    , tasty
-    , tasty-hunit
-    , tasty-quickcheck
+  build-depends: djot,
+                 directory,
+                 filepath,
+                 tasty,
+                 tasty-hunit,
+                 tasty-quickcheck
   default-language: Haskell2010
 
 benchmark benchmark-djot
+  import:          deps
   type:            exitcode-stdio-1.0
   main-is:         Main.hs
   hs-source-dirs:  benchmark
-  build-depends:
-       djot
-     , base >= 4.9 && < 5
-     , bytestring
-     , directory
-     , filepath
-     , doclayout
-     , tasty-bench
+  build-depends:   djot,
+                   directory,
+                   filepath,
+                   tasty-bench
   ghc-options: -O2 -threaded -rtsopts -with-rtsopts=-K10K -with-rtsopts=-kc10K
   if impl(ghc >= 8.10)
     ghc-options:      -Wunused-packages

--- a/djot.cabal
+++ b/djot.cabal
@@ -24,7 +24,8 @@ Library
                       mtl,
                       text,
                       doclayout,
-                      template-haskell
+                      template-haskell,
+                      th-lift-instances
     hs-source-dirs:   src
     default-language: Haskell2010
     exposed-modules:  Djot

--- a/djot.cabal
+++ b/djot.cabal
@@ -26,15 +26,9 @@ common deps
 Library
     import:           deps
     build-depends:    mtl,
+                      containers >= 0.6.6,
                       text,
                       template-haskell
-    if impl(ghc > 9.2)
-      build-depends:
-        containers >= 0.6.6
-    else
-      build-depends:
-        containers,
-        th-lift-instances
     hs-source-dirs:   src
     default-language: Haskell2010
     exposed-modules:  Djot

--- a/djot.cabal
+++ b/djot.cabal
@@ -21,12 +21,12 @@ common deps
   build-depends:
     base >= 4.12 && < 5,
     bytestring >= 0.11.3,
-    text,
     doclayout
 
 Library
     import:           deps
     build-depends:    mtl,
+                      text,
                       template-haskell
     if impl(ghc > 9.2)
       build-depends:
@@ -51,7 +51,8 @@ Library
 executable djoths
     import:           deps
     main-is:          Main.hs
-    build-depends:    djot
+    build-depends:    djot,
+                      text
     hs-source-dirs:   app
     default-language: Haskell2010
     ghc-options: -Wall -O2 -rtsopts -threaded
@@ -69,7 +70,8 @@ test-suite test-djot
                  filepath,
                  tasty,
                  tasty-hunit,
-                 tasty-quickcheck
+                 tasty-quickcheck,
+                 text
   default-language: Haskell2010
 
 benchmark benchmark-djot

--- a/djot.cabal
+++ b/djot.cabal
@@ -23,7 +23,8 @@ Library
                       containers,
                       mtl,
                       text,
-                      doclayout
+                      doclayout,
+                      template-haskell
     hs-source-dirs:   src
     default-language: Haskell2010
     exposed-modules:  Djot

--- a/src/Djot/AST.hs
+++ b/src/Djot/AST.hs
@@ -6,7 +6,6 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveLift #-}
-{-# LANGUAGE CPP #-}
 module Djot.AST
 ( Inline(..),
   Many(..),
@@ -90,12 +89,6 @@ import Data.Data (Data, Typeable)
 import qualified Data.ByteString.Char8 as B8
 import GHC.Generics (Generic)
 import Language.Haskell.TH.Syntax (Lift (..))
-#if ! MIN_VERSION_containers(0,6,6)
--- containers<0.6.6 does not have @Lift@ instances for some 
--- basic datatypes (@Map@, @Set@, @Seq@) so we import them 
--- if necessary.
-import Instances.TH.Lift
-#endif
 
 -- import Debug.Trace
 

--- a/src/Djot/AST.hs
+++ b/src/Djot/AST.hs
@@ -90,10 +90,10 @@ import Data.Data (Data, Typeable)
 import qualified Data.ByteString.Char8 as B8
 import GHC.Generics (Generic)
 import Language.Haskell.TH.Syntax (Lift (..))
-#if __GLASGOW_HASKELL__ <= 902 || ! MIN_VERSION_containers(0,6,6)
--- Old versions of GHC and the containers package don't have @Lift@ instances
--- for some basic datatypes (@Map@, @Set@, @Seq@) so we import them if
--- necessary.
+#if ! MIN_VERSION_containers(0,6,6)
+-- containers<0.6.6 does not have @Lift@ instances for some 
+-- basic datatypes (@Map@, @Set@, @Seq@) so we import them 
+-- if necessary.
 import Instances.TH.Lift
 #endif
 

--- a/src/Djot/AST.hs
+++ b/src/Djot/AST.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveLift #-}
 module Djot.AST
 ( Inline(..),
   Many(..),
@@ -87,11 +88,12 @@ import Data.Set (Set)
 import Data.Data (Data, Typeable)
 import qualified Data.ByteString.Char8 as B8
 import GHC.Generics (Generic)
+import Language.Haskell.TH.Syntax (Lift (..))
 
 -- import Debug.Trace
 
 newtype Attr = Attr [(ByteString, ByteString)]
-  deriving (Show, Eq, Ord, Typeable, Data, Generic)
+  deriving (Show, Eq, Ord, Typeable, Data, Generic, Lift)
 
 instance Semigroup Attr where
   Attr as <> Attr bs =
@@ -112,7 +114,7 @@ integrate (k,v) kvs =
       | otherwise -> kvs
 
 data Pos = NoPos | Pos Int Int Int Int -- start line, start col, end line, end col
-  deriving (Show, Eq, Ord, Typeable, Data, Generic)
+  deriving (Show, Eq, Ord, Typeable, Data, Generic, Lift)
 
 instance Semigroup Pos where
   Pos sl1 sc1 _ _ <> Pos _ _ el2 ec2 =
@@ -125,7 +127,7 @@ instance Monoid Pos where
   mempty = NoPos
 
 data Node a = Node Pos Attr a
-  deriving (Show, Eq, Ord, Functor, Traversable, Foldable, Typeable, Data, Generic)
+  deriving (Show, Eq, Ord, Functor, Traversable, Foldable, Typeable, Data, Generic, Lift)
 
 {-# INLINE addAttr #-}
 addAttr :: Attr -> Node a -> Node a
@@ -136,18 +138,18 @@ addPos :: Pos -> Node a -> Node a
 addPos pos (Node _ attr bs) = Node pos attr bs
 
 newtype Format = Format { unFormat :: ByteString }
-  deriving (Show, Eq, Ord, Typeable, Data, Generic)
+  deriving (Show, Eq, Ord, Typeable, Data, Generic, Lift)
 
 data MathStyle = DisplayMath | InlineMath
-  deriving (Show, Ord, Eq, Typeable, Data, Generic)
+  deriving (Show, Ord, Eq, Typeable, Data, Generic, Lift)
 
 data Target =
     Direct ByteString
   | Reference ByteString
-  deriving (Show, Ord, Eq, Typeable, Data, Generic)
+  deriving (Show, Ord, Eq, Typeable, Data, Generic, Lift)
 
 data QuoteType = SingleQuotes | DoubleQuotes
-  deriving (Show, Ord, Eq, Typeable, Data, Generic)
+  deriving (Show, Ord, Eq, Typeable, Data, Generic, Lift)
 
 data Inline =
       Str ByteString
@@ -172,10 +174,10 @@ data Inline =
     | Quoted QuoteType Inlines
     | SoftBreak
     | HardBreak
-    deriving (Show, Ord, Eq, Typeable, Data, Generic)
+    deriving (Show, Ord, Eq, Typeable, Data, Generic, Lift)
 
 newtype Many a = Many { unMany :: Seq a }
-  deriving (Show, Ord, Eq, Functor, Traversable, Foldable, Typeable, Data, Generic)
+  deriving (Show, Ord, Eq, Functor, Traversable, Foldable, Typeable, Data, Generic, Lift)
 
 type Inlines = Many (Node Inline)
 
@@ -216,37 +218,37 @@ instance Monoid Inlines where
   mempty = Many mempty
 
 data ListSpacing = Tight | Loose
-  deriving (Show, Ord, Eq, Typeable, Data, Generic)
+  deriving (Show, Ord, Eq, Typeable, Data, Generic, Lift)
 
 data OrderedListStyle =
   Decimal | LetterUpper | LetterLower | RomanUpper | RomanLower
-  deriving (Show, Ord, Eq, Typeable, Data, Generic)
+  deriving (Show, Ord, Eq, Typeable, Data, Generic, Lift)
 
 data OrderedListDelim =
   RightPeriod | RightParen | LeftRightParen
-  deriving (Show, Ord, Eq, Typeable, Data, Generic)
+  deriving (Show, Ord, Eq, Typeable, Data, Generic, Lift)
 
 data OrderedListAttributes =
   OrderedListAttributes
   { orderedListStyle :: OrderedListStyle
   , orderedListDelim :: OrderedListDelim
   , orderedListStart :: Int }
-  deriving (Show, Ord, Eq, Typeable, Data, Generic)
+  deriving (Show, Ord, Eq, Typeable, Data, Generic, Lift)
 
 data TaskStatus = Complete | Incomplete
-  deriving (Show, Ord, Eq, Typeable, Data, Generic)
+  deriving (Show, Ord, Eq, Typeable, Data, Generic, Lift)
 
 newtype Caption = Caption Blocks
-  deriving (Show, Ord, Eq, Typeable, Data, Generic)
+  deriving (Show, Ord, Eq, Typeable, Data, Generic, Lift)
 
 data Align = AlignLeft | AlignRight | AlignCenter | AlignDefault
-  deriving (Show, Ord, Eq, Typeable, Data, Generic)
+  deriving (Show, Ord, Eq, Typeable, Data, Generic, Lift)
 
 data CellType = HeadCell | BodyCell
-  deriving (Show, Ord, Eq, Typeable, Data, Generic)
+  deriving (Show, Ord, Eq, Typeable, Data, Generic, Lift)
 
 data Cell = Cell CellType Align Inlines
-  deriving (Show, Ord, Eq, Typeable, Data, Generic)
+  deriving (Show, Ord, Eq, Typeable, Data, Generic, Lift)
 
 data Block =
     Para Inlines
@@ -262,7 +264,7 @@ data Block =
   | ThematicBreak
   | Table (Maybe Caption) [[Cell]]
   | RawBlock Format ByteString
-  deriving (Show, Ord, Eq, Typeable, Data, Generic)
+  deriving (Show, Ord, Eq, Typeable, Data, Generic, Lift)
 
 type Blocks = Many (Node Block)
 
@@ -279,7 +281,7 @@ data Doc =
      , docReferences :: ReferenceMap
      , docAutoReferences :: ReferenceMap
      , docAutoIdentifiers :: Set ByteString
-     } deriving (Show, Ord, Eq, Typeable, Data, Generic)
+     } deriving (Show, Ord, Eq, Typeable, Data, Generic, Lift)
 
 instance Semigroup Doc where
   Doc bs ns rs ar ai <> Doc bs' ns' rs' ar' ai' =
@@ -291,7 +293,7 @@ instance Monoid Doc where
 
 -- | A map from labels to contents.
 newtype NoteMap = NoteMap { unNoteMap :: M.Map ByteString Blocks }
-  deriving (Show, Ord, Eq, Semigroup, Monoid, Typeable, Data, Generic)
+  deriving (Show, Ord, Eq, Semigroup, Monoid, Typeable, Data, Generic, Lift)
 
 insertNote :: ByteString -> Blocks -> NoteMap -> NoteMap
 insertNote label ref (NoteMap m) =
@@ -303,7 +305,7 @@ lookupNote label (NoteMap m) =
 
 newtype ReferenceMap =
   ReferenceMap { unReferenceMap :: M.Map ByteString (ByteString, Attr) }
-  deriving (Show, Ord, Eq, Semigroup, Monoid, Typeable, Data, Generic)
+  deriving (Show, Ord, Eq, Semigroup, Monoid, Typeable, Data, Generic, Lift)
 
 normalizeLabel :: ByteString -> ByteString
 normalizeLabel = B8.unwords . B8.splitWith isWs

--- a/src/Djot/AST.hs
+++ b/src/Djot/AST.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveLift #-}
+{-# LANGUAGE CPP #-}
 module Djot.AST
 ( Inline(..),
   Many(..),
@@ -89,6 +90,12 @@ import Data.Data (Data, Typeable)
 import qualified Data.ByteString.Char8 as B8
 import GHC.Generics (Generic)
 import Language.Haskell.TH.Syntax (Lift (..))
+#if __GLASGOW_HASKELL__ <= 902 || ! MIN_VERSION_containers(0,6,6)
+-- Old versions of GHC and the containers package don't have @Lift@ instances
+-- for some basic datatypes (@Map@, @Set@, @Seq@) so we import them if
+-- necessary.
+import Instances.TH.Lift
+#endif
 
 -- import Debug.Trace
 


### PR DESCRIPTION
I wanted to use Djot in some TH stuff, but generating expressions requires `Lift` instances. This PR just adds `DeriveLift` to the language extensions, and derives `Lift` instances for all of the datatypes in the `AST` module.